### PR TITLE
Remove failed bundlers from cache

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,11 @@ const onFile = file => {
       resolve(b.name)
     })
     // TODO handle error events bundler.on('error')
-    bundler.bundle().catch(reject)
+    bundler.bundle().catch((err) => {
+      bundler.stop()
+      delete bundlers[filePath]
+      reject(err)
+    })
   })
 
   // TODO: add cleanup when watching the file is no longer necessary


### PR DESCRIPTION
Parcel 1 has issues with worker farms as described in https://github.com/parcel-bundler/parcel/issues/2838.

Though this will probably be fixed with parcel 2, I want to propose a quickfix that allows users to create a retry-wrapper around this preprocessor. 